### PR TITLE
Mehrsprachige 404-Seiten bugfix

### DIFF
--- a/classes/class.seo42_rewrite.inc.php
+++ b/classes/class.seo42_rewrite.inc.php
@@ -141,7 +141,7 @@ class SEO42Rewrite
 			$langSlugs = array();
 
 			foreach ($REX['CLANG'] as $clangId => $clangName) {
-				$langSlugs[] = seo42::getLangSlug($clangId);
+				$langSlugs[$clangId] = seo42::getLangSlug($clangId);
 			}
 
 			$clangId = array_search($possibleLangSlug, $langSlugs);


### PR DESCRIPTION
Sollten die Sprachen in Redaxo nicht durchgehend nummeriert sein, da z.B.: eine Sprache gelöscht wird, stimmen hier die $langSlugs Indexe nicht. Deshalb kann es bei der Auflösung der $clangId für die 404-Seiten zu Fehlern kommen.